### PR TITLE
Added the abbreviations e.g. and i.e. to the pattern ABBREVS

### DIFF
--- a/src/cue/lang/SentenceIterator.java
+++ b/src/cue/lang/SentenceIterator.java
@@ -24,9 +24,9 @@ import java.util.regex.Pattern;
  * Construct with a {@link String}; retrieve a sequence of {@link String}s, each of
  * which is a "sentence" according to Java's built-in model for the given
  * {@link Locale}.
- * 
+ *
  * @author Jonathan Feinberg <jdf@us.ibm.com>
- * 
+ *
  */
 public class SentenceIterator extends IterableText
 {
@@ -52,7 +52,7 @@ public class SentenceIterator extends IterableText
 		advance();
 	}
 
-	private static final Pattern ABBREVS = Pattern.compile("(?:Mrs?|Ms|Dr|Rev)\\.\\s*$");
+	private static final Pattern ABBREVS = Pattern.compile("(?:Mrs?|Ms|Dr|Rev|e.g|i.e)\\.\\s*$");
 
 	private void advance()
 	{


### PR DESCRIPTION
Added these abbreviations to solve [this issue](https://github.com/vcl-xx/cue.language/issues/2), in which the sentence iterator incorrectly broke on "e.g." or "i.e."